### PR TITLE
test: reproduce #17 — enums used inside composite types must be emitted

### DIFF
--- a/squealgen.cabal
+++ b/squealgen.cabal
@@ -60,6 +60,7 @@ test-suite tests
       Domains.Public
       Enums.DBSpec
       CrossSchemaEnums.DBSpec
+      CrossSchemaEnumComposites.DBSpec
       Enums.Public
       Functions.DBSpec
       Functions.Public

--- a/squealgen.sql
+++ b/squealgen.sql
@@ -153,6 +153,20 @@ with used_enums as (
   join pg_catalog.pg_type base3 on (case when tret.typcategory = 'A' then base3.oid = elem3.oid else base3.oid = tret.oid end)
   where ns.nspname = :'chosen_schema'
     and base3.typcategory = 'E'
+  union
+  -- From composite type attributes in the chosen schema
+  select distinct (case when att_t.typcategory = 'A' then elem4.typname else att_t.typname end) as enumname
+  from pg_catalog.pg_type comp
+  join pg_catalog.pg_namespace comp_ns on comp_ns.oid = comp.typnamespace
+  join pg_catalog.pg_class comp_cls on comp.typrelid = comp_cls.oid
+  join pg_catalog.pg_attribute a on a.attrelid = comp.typrelid and a.attnum > 0 and not a.attisdropped
+  join pg_catalog.pg_type att_t on att_t.oid = a.atttypid
+  left join pg_catalog.pg_type elem4 on att_t.typcategory = 'A' and elem4.oid = att_t.typelem
+  join pg_catalog.pg_type base4 on (case when att_t.typcategory = 'A' then base4.oid = elem4.oid else base4.oid = att_t.oid end)
+  where comp_ns.nspname = :'chosen_schema'
+    and comp.typtype = 'c'
+    and comp_cls.relkind = 'c'
+    and base4.typcategory = 'E'
 ),
 enumerations as (
   select

--- a/test/CrossSchemaEnumComposites/DBSpec.hs
+++ b/test/CrossSchemaEnumComposites/DBSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+module CrossSchemaEnumComposites.DBSpec where
+
+import           Control.Exception        (SomeException, displayException, try)
+import qualified Data.ByteString.Char8    as BS8
+import           Database.Postgres.Temp
+import           System.Exit              (ExitCode (..))
+import           System.IO                as IO
+import           System.Process           (proc, readCreateProcessWithExitCode)
+import           Test.Hspec
+import           Squeal.PostgreSQL        (define, withConnection, Definition (UnsafeDefinition))
+
+spec :: Spec
+spec = describe "Cross-schema Enums in Composites" $ do
+  it "includes enums used inside composite types but not unrelated ones" $ do
+    res <- try @SomeException run :: IO (Either SomeException String)
+    case res of
+      Left e   -> expectationFailure ("setup failed: " <> displayException e)
+      Right hs -> do
+        -- enum referenced by a composite field in chosen schema should be present
+        hs `shouldContain` "type PGtraffic_light = 'PGenum"
+        -- unrelated enum from other schema should not be present
+        hs `shouldNotContain` "type PGunused_enum = 'PGenum"
+
+run :: IO String
+run = withDbCache $ \cache -> do
+  e <- withConfig (cacheConfig cache) $ \db -> do
+    let connBS = toConnectionString db
+    let setup = unlines
+          [ "CREATE SCHEMA one;"
+          , "CREATE SCHEMA two;"
+          , "CREATE TYPE two.traffic_light AS ENUM ('Red','Yellow','Green');"
+          , "CREATE TYPE two.unused_enum AS ENUM ('A','B');"
+          , "CREATE TYPE one.composite_thing AS ( status two.traffic_light );"
+          ]
+    withConnection connBS $ define (UnsafeDefinition (BS8.pack setup))
+    runSquealgen (BS8.unpack connBS) "CrossSchemaCompositeGenerated" "one"
+  case e of
+    Left err -> ioError (userError (displayException err))
+    Right x  -> pure x
+
+runSquealgen :: String -> String -> String -> IO String
+runSquealgen conn moduleName' chosen = do
+  script <- IO.readFile "squealgen.sql"
+  let cmd = proc "psql"
+        [ "-X"
+        , "-q"
+        , "-v", "chosen_schema=" <> chosen
+        , "-v", "modulename=" <> moduleName'
+        , "-v", "extra_imports="
+        , "-d", conn
+        ]
+  (exitCode, out, err) <- readCreateProcessWithExitCode cmd script
+  case exitCode of
+    ExitSuccess   -> pure out
+    ExitFailure c -> ioError (userError (unlines ["psql exited with code " <> show c, err]))
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified Composites.DBSpec
 import qualified Domains.DBSpec
 import qualified Enums.DBSpec
 import qualified CrossSchemaEnums.DBSpec
+import qualified CrossSchemaEnumComposites.DBSpec
 import qualified Functions.DBSpec
 import qualified InetArrays.DBSpec
 import qualified Members.DBSpec
@@ -30,6 +31,7 @@ main = do
     , testSpec "Domains.DB" Domains.DBSpec.spec
     , testSpec "Enums.DB" Enums.DBSpec.spec
     , testSpec "CrossSchemaEnums.DB" CrossSchemaEnums.DBSpec.spec
+    , testSpec "CrossSchemaEnumComposites.DB" CrossSchemaEnumComposites.DBSpec.spec
     , testSpec "Functions.DB" Functions.DBSpec.spec
     , testSpec "InetArrays.DB" InetArrays.DBSpec.spec
     , testSpec "Members.DB" Members.DBSpec.spec


### PR DESCRIPTION
This PR adds a failing test to reproduce #17.

Problem
- When generating for a chosen schema, enums from other schemas that are referenced inside composite types are not emitted.
- We currently restrict enums to only those actually used — but the usage detection misses composite attributes.

Test
- New spec CrossSchemaEnumComposites.DBSpec:
  - Creates schemas `one` and `two`.
  - Defines enum `two.traffic_light` and `two.unused_enum`.
  - Defines composite type `one.composite_thing(status two.traffic_light)`.
  - Runs squealgen for schema `one` and asserts:
    - The generated module includes `type PGtraffic_light = 'PGenum ...`
    - It does not include `PGunused_enum`.

Result
- Fails on current master, demonstrating the gap in enum usage detection.

Next
- I will push a follow-up commit to detect enums used in composite attributes and make the test pass.
